### PR TITLE
Retrive info failed eos

### DIFF
--- a/3-analyze/analysis-scripts/plot-box-plots/plot_box_and_violin.py
+++ b/3-analyze/analysis-scripts/plot-box-plots/plot_box_and_violin.py
@@ -8,7 +8,7 @@ import sys
 
 import quantities_for_comparison as qc
 
-EXPECTED_SCRIPT_VERSION = '0.0.3'
+EXPECTED_SCRIPT_VERSION = ['0.0.3','0.0.4']
 DEFAULT_PREFACTOR = 100
 DEFAULT_WB0 = 1.0 / 8.0
 DEFAULT_WB01 = 1.0 / 64.0
@@ -60,7 +60,7 @@ if __name__ == "__main__":
         data_dir = pl.Path(f'../../outputs')
         with open(f'{data_dir}/results-{SET_NAME}-{REF_PLUGIN}.json') as fhandle:
             ref_plugin_data = json.load(fhandle)
-            if not ref_plugin_data['script_version'] == EXPECTED_SCRIPT_VERSION:
+            if not ref_plugin_data['script_version'] in EXPECTED_SCRIPT_VERSION:
                 raise ValueError(
                     f"This script only works with data generated at version {EXPECTED_SCRIPT_VERSION}. "
                     f"Please re-run ./get_results.py to update the data format for results-{SET_NAME}-{REF_PLUGIN}.json!"
@@ -77,7 +77,7 @@ if __name__ == "__main__":
         plugin_name = filename.stem.replace(f'results-{SET_NAME}-', '')
         with open(filename, 'r') as fp:
             plugin_data = json.load(fp)
-            if plugin_data['script_version'] == EXPECTED_SCRIPT_VERSION:
+            if plugin_data['script_version'] in EXPECTED_SCRIPT_VERSION:
                 data[plugin_name] = plugin_data
 
     # Sort in alphabetical order

--- a/3-analyze/get_results.py
+++ b/3-analyze/get_results.py
@@ -17,7 +17,7 @@ from aiida.common import LinkType, NotExistentAttributeError
 from aiida_common_workflows.workflows.relax.workchain import CommonRelaxWorkChain
 
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 
 def extract_from_failed(node):
     """

--- a/3-analyze/outputs/generate_all_histos.py
+++ b/3-analyze/outputs/generate_all_histos.py
@@ -19,7 +19,7 @@ BINS = 100
 DEFAULT_PREFACTOR = 100
 DEFAULT_wb0 = 1.0/8.0
 DEFAULT_wb1 = 1.0/64.0
-EXPECTED_SCRIPT_VERSION = "0.0.3"
+EXPECTED_SCRIPT_VERSION = ["0.0.3","0.0.4"]
 LIMITS = {"V0_rel_diff":1,"B0_rel_diff":3,"B1_rel_diff":15}
 
 
@@ -49,7 +49,7 @@ if __name__ == "__main__":
     try:
         with open(f'results-{SET_NAME}-fleur.json') as fhandle:
             compare_plugin_data["fleur"] = json.load(fhandle)
-            if not compare_plugin_data["fleur"]['script_version'] == EXPECTED_SCRIPT_VERSION:
+            if not compare_plugin_data["fleur"]['script_version'] in EXPECTED_SCRIPT_VERSION:
                 raise ValueError(
                     f"This script only works with data generated at version {EXPECTED_SCRIPT_VERSION}. "
                     f"Please re-run ./get_results.py to update the data format for results-{SET_NAME}-fleur.json!"
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     try:
         with open(f'results-{SET_NAME}-wien2k.json') as fhandle:
             compare_plugin_data["wien2k"] = json.load(fhandle)
-            if not compare_plugin_data["wien2k"]['script_version'] == EXPECTED_SCRIPT_VERSION:
+            if not compare_plugin_data["wien2k"]['script_version'] in EXPECTED_SCRIPT_VERSION:
                 raise ValueError(
                     f"This script only works with data generated at version {EXPECTED_SCRIPT_VERSION}. "
                     f"Please re-run ./get_results.py to update the data format for results-{SET_NAME}-wien2k.json!"
@@ -85,7 +85,7 @@ if __name__ == "__main__":
                 continue
             with open(os.path.join(results_folder, fname)) as fhandle:
                 code_results[label] = json.load(fhandle)
-                if not code_results[label]['script_version'] == EXPECTED_SCRIPT_VERSION:
+                if not code_results[label]['script_version'] in EXPECTED_SCRIPT_VERSION:
                     raise ValueError(
                         f"This script only works with data generated at version {EXPECTED_SCRIPT_VERSION}. "
                         f"Please re-run ./get_results.py to update the data format for {fname}! Skipping {label}"

--- a/3-analyze/outputs/generate_all_periodic_table.py
+++ b/3-analyze/outputs/generate_all_periodic_table.py
@@ -14,7 +14,7 @@ SHOW_IN_BROWSER=True
 DEFAULT_PREFACTOR = 100
 DEFAULT_wb0 = 1.0/8.0
 DEFAULT_wb1 = 1.0/64.0
-EXPECTED_SCRIPT_VERSION = "0.0.3"
+EXPECTED_SCRIPT_VERSION = ["0.0.3","0.0.4"]
 
 
 from bokeh.models import (
@@ -84,7 +84,7 @@ if __name__ == "__main__":
     try:
         with open(f'results-{SET_NAME}-fleur.json') as fhandle:
             compare_plugin_data = json.load(fhandle)
-            if not compare_plugin_data['script_version'] == EXPECTED_SCRIPT_VERSION:
+            if not compare_plugin_data['script_version'] in EXPECTED_SCRIPT_VERSION:
                 raise ValueError(
                     f"This script only works with data generated at version {EXPECTED_SCRIPT_VERSION}. "
                     f"Please re-run ./get_results.py to update the data format for results-{SET_NAME}-fleur.json!"
@@ -106,7 +106,7 @@ if __name__ == "__main__":
                 continue
             with open(os.path.join(results_folder, fname)) as fhandle:
                 code_results[label] = json.load(fhandle)
-                if not code_results[label]['script_version'] == EXPECTED_SCRIPT_VERSION:
+                if not code_results[label]['script_version'] in EXPECTED_SCRIPT_VERSION:
                     raise ValueError(
                         f"This script only works with data generated at version {EXPECTED_SCRIPT_VERSION}. "
                         f"Please re-run ./get_results.py to update the data format for {fname}! Skipping {label}"

--- a/3-analyze/outputs/generate_histos.py
+++ b/3-analyze/outputs/generate_histos.py
@@ -41,7 +41,7 @@ BINS = 100
 DEFAULT_PREFACTOR = 100
 DEFAULT_wb0 = 1.0/8.0
 DEFAULT_wb1 = 1.0/64.0
-EXPECTED_SCRIPT_VERSION = "0.0.3"
+EXPECTED_SCRIPT_VERSION = ["0.0.3","0.0.4"]
 
 
 def gaussian(x, a, x0, sigma):
@@ -88,7 +88,7 @@ if __name__ == "__main__":
         print(f"No data found for your plugin '{PLUGIN_NAME}' (set '{SET_NAME}'). Did you run `./get_results.py` first?")
         sys.exit(1)
  
-    if not reference_plugin_data['script_version'] == EXPECTED_SCRIPT_VERSION:
+    if not reference_plugin_data['script_version'] in EXPECTED_SCRIPT_VERSION:
         raise ValueError(
             f"This script only works with data generated at version {EXPECTED_SCRIPT_VERSION}. "
             f"Please re-run ./get_results.py to update the data format for {PLUGIN_NAME}!"
@@ -101,7 +101,7 @@ if __name__ == "__main__":
         try:
             with open(f'results-{SET_NAME}-{compare_with}.json') as fhandle:
                 compare_plugin_data.append(json.load(fhandle))
-            if not compare_plugin_data[-1]['script_version'] == EXPECTED_SCRIPT_VERSION:
+            if not compare_plugin_data[-1]['script_version'] in EXPECTED_SCRIPT_VERSION:
                 raise ValueError(
                     f"This script only works with data generated at version {EXPECTED_SCRIPT_VERSION}. "
                     f"Please re-run ./get_results.py to update the data format for {compare_with}!"

--- a/3-analyze/outputs/generate_periodic_table.py
+++ b/3-analyze/outputs/generate_periodic_table.py
@@ -14,7 +14,7 @@ SHOW_IN_BROWSER=False
 DEFAULT_PREFACTOR = 100
 DEFAULT_wb0 = 1.0/8.0
 DEFAULT_wb1 = 1.0/64.0
-EXPECTED_SCRIPT_VERSION = "0.0.3"
+EXPECTED_SCRIPT_VERSION = ["0.0.3","0.0.4"]
 
 
 from bokeh.models import (
@@ -124,7 +124,7 @@ if __name__ == "__main__":
         print(f"No data found for code '{other_code}' (set '{SET_NAME}'). A file results-{SET_NAME}-{other_code}.json is expected")
         sys.exit(1)
 
-    if not reference_plugin_data['script_version'] == EXPECTED_SCRIPT_VERSION:
+    if not reference_plugin_data['script_version'] in EXPECTED_SCRIPT_VERSION:
         raise ValueError(
             f"This script only works with data generated at version {EXPECTED_SCRIPT_VERSION}. "
             f"Please re-run ./get_results.py to update the data format for {PLUGIN_NAME}!"

--- a/3-analyze/outputs/generate_plots.py
+++ b/3-analyze/outputs/generate_plots.py
@@ -31,7 +31,7 @@ def get_plugin_name():
 
 PLUGIN_NAME = get_plugin_name()
 
-EXPECTED_SCRIPT_VERSION = '0.0.3'
+EXPECTED_SCRIPT_VERSION = ['0.0.3','0.0.4']
 RESIDUALS_THRESHOLD = 1.e-3
 
 def get_conf_nice(configuration_string):
@@ -64,7 +64,7 @@ if __name__ == "__main__":
         print(f"No data found for your plugin '{PLUGIN_NAME}' (set '{SET_NAME}'). Did you run `./get_results.py` first?")
         sys.exit(1)
     
-    if not reference_plugin_data['script_version'] == EXPECTED_SCRIPT_VERSION:
+    if not reference_plugin_data['script_version'] in EXPECTED_SCRIPT_VERSION:
         raise ValueError(
             f"This script only works with data generated at version {EXPECTED_SCRIPT_VERSION}. "
             "Please re-run ./get_results.py to update the data format!")
@@ -81,7 +81,7 @@ if __name__ == "__main__":
         except OSError:
             print(f"No data found for the reference plugin '{compare_with}': you need the file results-{SET_NAME}-{compare_with}.json.")
             sys.exit(1)
-        if not compare_plugin_data['script_version'] == EXPECTED_SCRIPT_VERSION:
+        if not compare_plugin_data['script_version'] in EXPECTED_SCRIPT_VERSION:
             raise ValueError(
                 f"This script only works with data generated at version {EXPECTED_SCRIPT_VERSION}. "
                 "Please ask the other plugin you want to compare with to re-run ./get_results.py "

--- a/3-analyze/outputs/generate_plots.py
+++ b/3-analyze/outputs/generate_plots.py
@@ -196,6 +196,12 @@ if __name__ == "__main__":
                     160.21766208 * (stress_tensor[0][0] + stress_tensor[1][1] + stress_tensor[2][2])/3
                     )
 
+        # Check missing data
+        miss_data = False
+        if reference_plugin_data["missing_outputs"]:
+            if f'{element}-{configuration}' in reference_plugin_data['missing_outputs']:
+                miss_data = True
+
         #### START Plotting ####
         if hydro_stresses_GPa:
             fig, (stress_ax, eos_ax) = pl.subplots(nrows=2, ncols=1, gridspec_kw={'height_ratios': [1, 2], 'left': 0.15, 'right': 0.95}, sharex=True)
@@ -218,6 +224,9 @@ if __name__ == "__main__":
 
         LIGHTYELLOW = (255/255, 244/255, 214/255)
         LIGHTORANGE = (255/255, 205/255, 171/255)
+        LIGHTGREEN = (144/255, 238/255, 144/255)
+        if miss_data:
+            eos_ax.set_facecolor(LIGHTGREEN)
         if residuals is None:
             eos_ax.set_facecolor(LIGHTYELLOW)
         elif residuals > RESIDUALS_THRESHOLD:


### PR DESCRIPTION
@giovannipizzi I tested with Oleg's set and is working fine, however there is an important comment.
The point of this PR is to try to retrieve results of a failed EoS worchain, check if enough volumes were calculated correctly and  return the results in case.
However this is possible only if the `<Code>CommonRelaxWorkChain` implementation (used to get the energy at each volume) returns in output a `relaxed_structure`. In fact  `<Code>CommonRelaxWorkChain` has a standardized set of outputs, NOT inputs. If the `relaxed_structure` is not present, we do not know how to retrieve the volume in a common way: some implementation call the input structure just `structure`, some others `aiida_structure`, some others  `scf.structure` and so on.
At the moment, if  `relaxed_structure` is not present, nothing is retrieved and the calculation is listed as failed. I do not know how many implementations return a `relaxed_structure` when only an scf is run.
In general this is another drawback to not have the inputs of the input generator stored.  