### PR TITLE
Box and violin plot script

### DIFF
--- a/3-analyze/analysis-scripts/plot-box-plots/plot_box_and_violin.py
+++ b/3-analyze/analysis-scripts/plot-box-plots/plot_box_and_violin.py
@@ -1,0 +1,212 @@
+# %%
+import json
+import pathlib as pl
+import numpy as np
+import matplotlib.pyplot as plt
+import tabulate
+
+import quantities_for_comparison as qc
+
+EXPECTED_SCRIPT_VERSION = '0.0.3'
+DEFAULT_PREFACTOR = 100
+DEFAULT_WB0 = 1.0 / 8.0
+DEFAULT_WB01 = 1.0 / 64.0
+
+CAPPROPS = {
+    'linewidth': 1,
+    'color': 'tab:green'
+}
+BOXPROPS = {
+    'linewidth': 1,
+    'color': 'tab:green'
+}
+WHISKERPROPS = {
+    'linewidth': 1,
+    'color': 'tab:green'
+}
+MEDIANPROPS = {
+    'linewidth': 1,
+    'color': 'tab:blue'
+}
+FLIERPROPS = {
+    'marker': '.',
+    'linestyle': '',
+    'markerfacecolor': 'tab:grey',
+    'markeredgewidth': 0,
+    'markersize': 3
+}
+# %%
+set_name = 'oxides-verification-PBE-v1'
+reference_plugin_name = 'wien2k_dk_0.06'
+data_dir = pl.Path(f'../../outputs')
+quantity_names = ['min_volume', 'bulk_modulus_ev_ang3', 'bulk_deriv', 'delta_per_formula_unit', 'epsilon']
+# %%
+data = {}
+for filename in data_dir.glob(f'results-{set_name}*json'):
+    plugin_name = filename.stem.replace(f'results-{set_name}-', '')
+    with open(filename, 'r') as fp:
+        plugin_data = json.load(fp)
+        if plugin_data['script_version'] == EXPECTED_SCRIPT_VERSION:
+            data[plugin_name] = plugin_data
+
+pretty_plugin_name_map = {
+    'quantum_espresso': 'Quantum ESPRESSO',
+    'mk2-castep': 'CASTEP v2',
+    'abinit-PseudoDojo-0.4-PBE-SR-standard-psp8': 'ABINIT NC v0.4',
+    'cp2k_DZVP': 'CP2K DZVP',
+    'fleur': 'Fleur',
+    'castep': 'CASTEP',
+    'gpaw': 'gpaw',
+    'abinit-PseudoDojo-0.5b1-PBE-SR-standard-psp8': 'ABINIT NC v0.5b1',
+    'vasp_recpot_e700': 'VASP recpot e700',
+    'wien2k_dk_0.06': 'Wien2k',
+    'vasp_recpot': 'VASP recpot',
+    'abinit-JTH-1.1-PBE': 'ABINIT PAW v1.1'
+}
+
+quantity_name_map = {
+    'bulk_modulus_ev_ang3': '$\Delta B_0$ [%]',
+    'E0': '$E_0$ [eV]',
+    'bulk_deriv': '$\Delta B_1$ [%]',
+    'min_volume': '$\Delta V_0$ [%]',
+    'delta_per_formula_unit': '$\Delta$',
+    'epsilon': r'$\varepsilon$'
+}
+
+text_quantity_name_map = {
+    'bulk_modulus_ev_ang3': 'dB0 [%]',
+    'bulk_deriv': 'dB1 [%]',
+    'min_volume': 'dV0 [%]',
+    'delta_per_formula_unit': 'Delta',
+    'epsilon': 'Epsilon'
+}
+
+quantity_for_comparison_map = {
+    "delta_per_formula_unit": qc.delta,
+    "bulk_modulus_ev_ang3": qc.B0_rel_diff,
+    "min_volume": qc.V0_rel_diff,
+    "bulk_deriv": qc.B1_rel_diff,
+    "rel_errors_vec_length": qc.rel_errors_vec_length,
+    "epsilon": qc.epsilon
+}
+# %%
+# Sort in alphabetical order
+plugin_names = sorted(list(data.keys()))[::-1]
+# Remove the reference plugin from the list
+plugin_names = [plugin_name for plugin_name in plugin_names if plugin_name != reference_plugin_name]
+
+ref_data = data[reference_plugin_name]
+ref_BM_fit_data = ref_data['BM_fit_data']
+# List the reference systems that have BM fit data
+ref_systems = set(
+    el_conf for el_conf in ref_BM_fit_data.keys()
+    if ref_BM_fit_data[el_conf] is not None
+)
+
+# Set up a place to store all the plotting data
+quantity_data = {plugin_name: {} for plugin_name in plugin_names}
+for quantity_name in quantity_names:
+    for plugin_name in plugin_names:
+        plugin_values = []
+
+        plugin_data = data[plugin_name]
+        plugin_BM_fit_data = data[plugin_name]['BM_fit_data']
+
+        plugin_systems = set(
+            el_conf for el_conf in plugin_BM_fit_data.keys()
+            if plugin_BM_fit_data[el_conf] is not None
+        )
+        # Take the systems that are both in the reference and plugin sets
+        plot_systems = plugin_systems.intersection(ref_systems)
+
+        for element_and_configuration in plot_systems:
+            element, configuration = element_and_configuration.split('-')
+            
+            ref_n_atoms = ref_data['num_atoms_in_sim_cell'][f'{element}-{configuration}']
+            ref_scaling_factor = qc.get_volume_scaling_to_formula_unit(
+                ref_n_atoms, element, configuration
+            )
+            ref_V0 = ref_BM_fit_data[f'{element}-{configuration}']['min_volume'] / ref_scaling_factor
+            ref_B0 = ref_BM_fit_data[f'{element}-{configuration}']['bulk_modulus_ev_ang3']
+            ref_B01 = ref_BM_fit_data[f'{element}-{configuration}']['bulk_deriv']
+
+            plugin_n_atoms = plugin_data['num_atoms_in_sim_cell'][f'{element}-{configuration}']
+            plugin_scaling_factor = qc.get_volume_scaling_to_formula_unit(
+                plugin_n_atoms, element, configuration
+            )
+            plugin_V0 = plugin_BM_fit_data[f'{element}-{configuration}']['min_volume'] / plugin_scaling_factor
+            plugin_B0 = plugin_BM_fit_data[f'{element}-{configuration}']['bulk_modulus_ev_ang3']
+            plugin_B01 = plugin_BM_fit_data[f'{element}-{configuration}']['bulk_deriv']
+
+            quantity_value = quantity_for_comparison_map[quantity_name](
+                ref_V0, ref_B0, ref_B01,
+                plugin_V0, plugin_B0, plugin_B01,
+                DEFAULT_PREFACTOR, DEFAULT_WB0, DEFAULT_WB01
+            )
+
+            plugin_values.append(quantity_value)
+            quantity_data[plugin_name][quantity_name] = plugin_values
+
+# %%
+# Set up the plot axes for each quantity
+n_quantities = len(quantity_names)
+fig, axes = plt.subplots(1, n_quantities, dpi=300, figsize=(4 * n_quantities, 4), sharey=True)
+axes = axes.flatten()
+
+for quantity_name, ax in zip(quantity_names, axes):
+    quantity_values = [quantity_data[plugin_name][quantity_name] for plugin_name in plugin_names]
+    
+    violin_parts = ax.violinplot(
+        quantity_values,
+        widths=0.75,
+        points=1000,
+        showextrema=False, showmedians=False,  # These are shown by the box plots
+        vert=False
+    )
+    for part in violin_parts['bodies']:
+        part.set_facecolor('tab:grey')
+        part.set_alpha(0.50)
+    
+    ax.boxplot(
+        quantity_values,
+        flierprops=FLIERPROPS,
+        boxprops=BOXPROPS,
+        whiskerprops=WHISKERPROPS,
+        medianprops=MEDIANPROPS,
+        capprops=CAPPROPS,
+        vert=False,
+        labels=[pretty_plugin_name_map[plugin_name] for plugin_name in plugin_names]
+    )
+    ax.set_xlabel(quantity_name_map[quantity_name], fontsize=14)
+
+fig.suptitle(f'{pretty_plugin_name_map[reference_plugin_name]} Reference')
+fig.tight_layout()
+
+fig.savefig('boxplots.pdf')
+
+# %%
+def make_quantity_table(function, quantity_data):
+    table = []
+    for plugin_name in plugin_names:
+        row = [pretty_plugin_name_map[plugin_name]]
+        for quantity_name in quantity_names:
+            val = function(quantity_data[plugin_name][quantity_name])
+            row.append(val)
+        table.append(row)
+    table = table[::-1]
+
+    return tabulate.tabulate(
+        table, headers=['Plugin'] + [text_quantity_name_map[quantity_name] for quantity_name in quantity_names]
+    )
+
+# %%
+table = make_quantity_table(lambda x: np.median(x), quantity_data)
+print('MEDIAN\n' + table)
+# %%
+table = make_quantity_table(lambda x: np.mean(x), quantity_data)
+print('MEAN\n' + table)
+# %%
+table = make_quantity_table(lambda x: np.quantile(x, 0.75) - np.quantile(x, 0.25), quantity_data)
+print('IQR\n' + table)
+
+# %%

--- a/3-analyze/analysis-scripts/plot-box-plots/quantities_for_comparison.py
+++ b/3-analyze/analysis-scripts/plot-box-plots/quantities_for_comparison.py
@@ -1,0 +1,290 @@
+import numpy as np
+
+def get_num_atoms_in_formula_unit(configuration):
+    """Return the number ot atoms per formula unit.
+
+    For unaries, it's the number in the primitive cell: 1 for SC, BCC, FCC; 2 for diamond.
+    """
+    mapping = {
+        'XO': 2,
+        'XO2': 3,
+        'X2O': 3,
+        'X2O3': 5,
+        'XO3': 4,
+        'X2O5': 7,
+        'X/Diamond': 2,
+        'X/SC': 1,
+        'X/FCC': 1,
+        'X/BCC': 1
+    }
+
+    try:
+        return mapping[configuration]
+    except KeyError:
+        raise ValueError(f"Unknown number of atoms in formula unit for configuration '{configuration}'")
+
+
+def get_volume_scaling_to_formula_unit(num_atoms_in_cell, element, configuration):
+    """Return the scaling factor for extensive quantities (energies, volumes, ...).
+
+    The volume per formula unit is the volume in the simulation cell (with `num_atoms_in_cell`)
+    DIVIDED by the value returned by this function.
+    """
+    num_atoms_in_formula_unit = get_num_atoms_in_formula_unit(configuration)
+
+    if element != "O":
+        # For oxygen I might get a smaller cell;
+        # the remaining logic is still correct (I divide by 0.5 => multiply by 2
+        # if there is e.g. 1 atom in XO but the number of atoms in the formula unit is 2)
+        assert num_atoms_in_cell % num_atoms_in_formula_unit == 0, (
+            f"Weird! {num_atoms_in_cell} atoms in cell but "
+            f"{num_atoms_in_formula_unit} in formula unit for {element}-{configuration}!")
+
+    scaling = num_atoms_in_cell / num_atoms_in_formula_unit
+    return scaling
+
+def birch_murnaghan(V,E0,V0,B0,B01):
+    """
+    Return the energy for given volume (V - it can be a vector) according to
+    the Birch Murnaghan function with parameters E0,V0,B0,B01.
+    """
+    r = (V0/V)**(2./3.)
+    return (E0 +
+            9./16. * B0 * V0 * (
+            (r-1.)**3 * B01 + 
+            (r-1.)**2 * (6. - 4.* r)))
+
+
+def intE12sq(v0w,b0w,b1w,v0f,b0f,b1f,V1,V2):
+    """
+    Integral of (E1(V) - E2(V))**2 in dV evaluated between volume V1 and volume V2
+    """
+    F1 = antiderE12sq(v0w,b0w,b1w,v0f,b0f,b1f,V1)
+    F2 = antiderE12sq(v0w,b0w,b1w,v0f,b0f,b1f,V2)
+    integral = F2 - F1
+
+    return integral
+
+def antiderE12sq(v0w,b0w,b1w,v0f,b0f,b1f,V):
+    """
+    Antiderivative of (E1(V) - E2(V))**2 where E1(V) and E2(V) are birch murnaghan
+    functions with different parameters
+    """
+    antider = (81*(\
+            6*b0w*b0f*(-16 + 3*b1w)*(-16 + 3*b1f)*V*v0w*(v0w/V)**(2/3)*v0f*(v0f/V)**(2/3) - \
+            2*b0w*b0f*(-14 + 3*b1w)*(-16 + 3*b1f)*V*v0w*(v0w/V)**(4/3)*v0f*(v0f/V)**(2/3) - \
+            2*b0w*b0f*(-16 + 3*b1w)*(-14 + 3*b1f)*V*v0w*(v0w/V)**(2/3)*v0f*(v0f/V)**(4/3) + \
+            (6*b0w*b0f*(-14 + 3*b1w)*(-14 + 3*b1f)*V*v0w*(v0w/V)**(4/3)*v0f*(v0f/V)**(4/3))/5. + \
+            V*(b0w*(-6 + b1w)*v0w - b0f*(-6 + b1f)*v0f)**2 - \
+            (b0w*(-4 + b1w)*v0w**3 - b0f*(-4 + b1f)*v0f**3)**2/(3.*V**3) + \
+            (3*b0f*(v0f/V)**(7/3)*(-2*b0w*(-14 + 3*b1f)*v0w*(-7*(-6 + b1w)*V**2 + \
+            (-4 + b1w)*v0w**2) \
+            - 7*b0f*(424 + 5*b1f*(-32 + 3*b1f))*V**2*\
+            v0f + 2*b0f*(-4 + b1f)*(-14 + 3*b1f)*\
+            v0f**3))/7. - \
+            (3*b0f*(v0f/V)**(5/3)*\
+            (-2*b0w*(-16 + 3*b1f)*v0w*\
+            (5*(-6 + b1w)*V**2 + (-4 + b1w)*v0w**2) \
+            + 10*b0f*(-6 + b1f)*(-16 + 3*b1f)*V**2*\
+            v0f + b0f*(324 + 5*b1f*(-28 + 3*b1f))*\
+            v0f**3))/5. +\
+            (4*b0w**2*(124 + 5*(-10 + b1w)*b1w)*v0w**4 - \
+            2*b0w*b0f*(-4 + b1w)*(-6 + b1f)*v0w**3*\
+            v0f - 2*b0w*b0f*(-6 + b1w)*(-4 + b1f)*v0w*\
+            v0f**3 + 4*b0f**2*(124 + 5*(-10 + b1f)*b1f)*v0f**4)/V + \
+            (3*b0w*(v0w/V)**(7/3)*\
+            (-7*b0w*(424 + 5*b1w*(-32 + 3*b1w))*V**2*\
+            v0w + 2*b0w*(-4 + b1w)*(-14 + 3*b1w)*v0w**3 + \
+            2*b0f*(-14 + 3*b1w)*v0f*\
+            (7*(-6 + b1f)*V**2 - (-4 + b1f)*v0f**2)))/7. - \
+            (3*b0w*(v0w/V)**(5/3)*\
+            (10*b0w*(-6 + b1w)*(-16 + 3*b1w)*V**2*v0w + \
+            b0w*(324 + 5*b1w*(-28 + 3*b1w))*v0w**3 - \
+            2*b0f*(-16 + 3*b1w)*v0f*\
+            (5*(-6 + b1f)*V**2 + (-4 + b1f)*v0f**2)))/5.))/256.
+
+    return antider
+
+def intEdV(V0,B0,B0pr,V1,V2):
+    """
+    integral of E(V) in dV evaluated between volumes V1 and V2
+    """
+    F1 = antiderE(V0,B0,B0pr,V1)
+    F2 = antiderE(V0,B0,B0pr,V2)
+    integral = F2 - F1
+
+    return integral
+
+def antiderE(V0,B0,B0pr,V):
+    """
+    antiderivative of the Birch Murnaghan E(V)
+    """
+    antider = (9*B0*V0*(-((-6 + B0pr)*V) - ((-4 + B0pr)*V0**2)/V + \
+            3*(-14 + 3*B0pr)*V0*(V0/V)**(1/3) + \
+            3*(-16 + 3*B0pr)*V*(V0/V)**(2/3)))/16
+
+    return antider
+
+def intE2dV(V0,B0,B0pr,V1,V2):
+    """
+    Integral of E**2(V) in dV evaluated between volume V1 and volume V2
+    """
+    F1 = antiderE2(V0,B0,B0pr,V1)
+    F2 = antiderE2(V0,B0,B0pr,V2)
+    integral = F2 - F1
+
+    return integral
+
+def antiderE2(V0,B0,B0pr,V):
+    """
+    Antiderivative of the Birch Murnaghan squared (E**2(V))
+    """
+    antider = (81*B0**2*V0**2*((-6 + B0pr)**2*V + \
+            (4*(124 + 5*(-10 + B0pr)*B0pr)*V0**2)/V - \
+            ((-4 + B0pr)**2*V0**4)/(3.*V**3) - \
+            (3*(V0/V)**(2/3)* \
+            (10*(-6 + B0pr)*(-16 + 3*B0pr)*V**2 + \
+            (324 + 5*B0pr*(-28 + 3*B0pr))*V0**2))/(5.*V) \
+            + (V0/V)**(1/3)* \
+            (-3*(424 + 5*B0pr*(-32 + 3*B0pr))*V0 + \
+            (6*(-4 + B0pr)*(-14 + 3*B0pr)*V0**3)/(7.*V**2))) \
+            )/256.
+
+    return antider
+
+def delta(v0w, b0w, b1w, v0f, b0f, b1f, prefact, weight_b0, weight_b1):
+    """
+    Calculate the Delta value, function copied from the official DeltaTest repository.
+    I don't understand what it does, but it works. Result is in meV
+    THE SIGNATURE OF THIS FUNCTION HAS BEEN CHOSEN TO MATCH THE ONE OF ALL THE OTHER FUNCTIONS
+    RETURNING A QUANTITY THAT IS USEFUL FOR COMPARISON, THIS SIMPLIFIES THE CODE LATER.
+    """
+
+    Vi = 0.94 * (v0w + v0f) / 2.
+    Vf = 1.06 * (v0w + v0f) / 2.
+
+    a3f = 9. * v0f**3. * b0f / 16. * (b1f - 4.)
+    a2f = 9. * v0f**(7. / 3.) * b0f / 16. * (14. - 3. * b1f)
+    a1f = 9. * v0f**(5. / 3.) * b0f / 16. * (3. * b1f - 16.)
+    a0f = 9. * v0f * b0f / 16. * (6. - b1f)
+
+    a3w = 9. * v0w**3. * b0w / 16. * (b1w - 4.)
+    a2w = 9. * v0w**(7. / 3.) * b0w / 16. * (14. - 3. * b1w)
+    a1w = 9. * v0w**(5. / 3.) * b0w / 16. * (3. * b1w - 16.)
+    a0w = 9. * v0w * b0w / 16. * (6. - b1w)
+
+    x = [0, 0, 0, 0, 0, 0, 0]
+
+    x[0] = (a0f - a0w)**2
+    x[1] = 6. * (a1f - a1w) * (a0f - a0w)
+    x[2] = -3. * (2. * (a2f - a2w) * (a0f - a0w) + (a1f - a1w)**2.)
+    x[3] = -2. * (a3f - a3w) * (a0f - a0w) - 2. * (a2f - a2w) * (a1f - a1w)
+    x[4] = -3. / 5. * (2. * (a3f - a3w) * (a1f - a1w) + (a2f - a2w)**2.)
+    x[5] = -6. / 7. * (a3f - a3w) * (a2f - a2w)
+    x[6] = -1. / 3. * (a3f - a3w)**2.
+
+    y = [0, 0, 0, 0, 0, 0, 0]
+
+    y[0] = (a0f + a0w)**2 / 4.
+    y[1] = 3. * (a1f + a1w) * (a0f + a0w) / 2.
+    y[2] = -3. * (2. * (a2f + a2w) * (a0f + a0w) + (a1f + a1w)**2.) / 4.
+    y[3] = -(a3f + a3w) * (a0f + a0w) / 2. - (a2f + a2w) * (a1f + a1w) / 2.
+    y[4] = -3. / 20. * (2. * (a3f + a3w) * (a1f + a1w) + (a2f + a2w)**2.)
+    y[5] = -3. / 14. * (a3f + a3w) * (a2f + a2w)
+    y[6] = -1. / 12. * (a3f + a3w)**2.
+
+    Fi = np.zeros_like(Vi)
+    Ff = np.zeros_like(Vf)
+
+    Gi = np.zeros_like(Vi)
+    Gf = np.zeros_like(Vf)
+
+    for n in range(7):
+        Fi = Fi + x[n] * Vi**(-(2. * n - 3.) / 3.)
+        Ff = Ff + x[n] * Vf**(-(2. * n - 3.) / 3.)
+
+        Gi = Gi + y[n] * Vi**(-(2. * n - 3.) / 3.)
+        Gf = Gf + y[n] * Vf**(-(2. * n - 3.) / 3.)
+
+    Delta = 1000. * np.sqrt((Ff - Fi) / (Vf - Vi))
+    #Deltarel = 100. * np.sqrt((Ff - Fi) / (Gf - Gi))
+    #vref = 30.
+    #bref = 100. * 10.**9. / 1.602176565e-19 / 10.**30. #100 GPa in ev_ang3
+    #Delta1 = 1000. * np.sqrt((Ff - Fi) / (Vf - Vi)) \
+    #    / (v0w + v0f) / (b0w + b0f) * 4. * vref * bref
+
+    return Delta  #, Deltarel, Delta1
+
+
+
+def epsilon(v0w, b0w, b1w, v0f, b0f, b1f, prefact, weight_b0, weight_b1):
+    """
+    Calculate alternative Delta2 based on 2 EOS fits
+    THE SIGNATURE OF THIS FUNCTION HAS BEEN CHOSEN TO MATCH THE ONE OF ALL THE OTHER FUNCTIONS
+    RETURNING A QUANTITY THAT IS USEFUL FOR COMPARISON, THIS SIMPLIFIES THE CODE LATER.
+    """
+
+    # volume range
+    Vi = 0.94 * (v0w + v0f) / 2.
+    Vf = 1.06 * (v0w + v0f) / 2.
+    deltaV = Vf - Vi
+
+    intdiff2 = intE12sq(v0w,b0w,b1w,v0f,b0f,b1f,Vi,Vf)
+    Eavg1 = intEdV(v0w,b0w,b1w,Vi,Vf)/deltaV
+    Eavg2 = intEdV(v0w,b0w,b1w,Vi,Vf)/deltaV
+    int3 = intE2dV(v0w,b0w,b1w,Vi,Vf) - \
+            2*Eavg1*intEdV(v0w,b0w,b1w,Vi,Vf) + \
+            deltaV*Eavg1**2 # integrate (ene - mean(ene))**2
+    int4 = intE2dV(v0f,b0f,b1f,Vi,Vf) - \
+            2*Eavg2*intEdV(v0f,b0f,b1f,Vi,Vf) + \
+            deltaV*Eavg2**2
+    eps2 = intdiff2/np.sqrt(int3*int4)
+
+    #We saw a case when, for numerical error, intdiff2 was negative
+    #(about -1*10^{-13}). For this reason, we add a safty check.
+    if eps2 < 0.0:
+        print(f"eps2 = {eps2}, negative due to numerical error probably, we take the absolute value")
+        eps2 = abs(eps2)
+    
+    return np.sqrt(eps2)*prefact
+
+
+def V0_rel_diff(v0w, b0w, b1w, v0f, b0f, b1f, prefact, weight_b0, weight_b1):
+    """
+    Returns the relative difference in the volumes.
+    THE SIGNATURE OF THIS FUNCTION HAS BEEN CHOSEN TO MATCH THE ONE OF ALL THE OTHER FUNCTIONS
+    RETURNING A QUANTITY THAT IS USEFUL FOR COMPARISON, THIS SIMPLIFIES THE CODE LATER.
+    Even though several inputs are useless here.
+    """
+    return prefact*2*(v0w-v0f)/(v0w+v0f)
+
+
+def B0_rel_diff(v0w, b0w, b1w, v0f, b0f, b1f, prefact, weight_b0, weight_b1):
+    """
+    Returns the relative difference in the bulk modulus.
+    THE SIGNATURE OF THIS FUNCTION HAS BEEN CHOSEN TO MATCH THE ONE OF ALL THE OTHER FUNCTIONS
+    RETURNING A QUANTITY THAT IS USEFUL FOR COMPARISON, THIS SIMPLIFIES THE CODE LATER.
+    Even though several inputs are useless here.
+    """
+    return prefact*2*(b0w-b0f)/(b0w+b0f)
+
+def B1_rel_diff(v0w, b0w, b1w, v0f, b0f, b1f, prefact, weight_b0, weight_b1):
+    """
+    Returns the reletive difference in the derivative of the bulk modulus.
+    THE SIGNATURE OF THIS FUNCTION HAS BEEN CHOSEN TO MATCH THE ONE OF ALL THE OTHER FUNCTIONS
+    RETURNING A QUANTITY THAT IS USEFUL FOR COMPARISON, THIS SIMPLIFIES THE CODE LATER.
+    Even though several inputs are useless here.
+    """
+    return prefact*2*(b1w-b1f)/(b1w+b1f)
+
+def rel_errors_vec_length(v0w, b0w, b1w, v0f, b0f, b1f, prefact, weight_b0, weight_b1):
+    """
+    Returns the length of the vector formed by the relative error of V0, B0, B1
+    THE SIGNATURE OF THIS FUNCTION HAS BEEN CHOSEN TO MATCH THE ONE OF ALL THE OTHER FUNCTIONS
+    RETURNING A QUANTITY THAT IS USEFUL FOR COMPARISON, THIS SIMPLIFIES THE CODE LATER.
+    """
+    V0err =  2*(v0w-v0f)/(v0w+v0f)
+    B0err =  2*(b0w-b0f)/(b0w+b0f)
+    B1err =  2*(b1w-b1f)/(b1w+b1f)
+    leng = np.sqrt(V0err**2+(weight_b0*B0err)**2+(weight_b1*B1err)**2)
+    return leng*prefact


### PR DESCRIPTION
As a proposed solution for how to visualize the figure of merit data (e.g. % difference in V0, Delta, etc.), I wrote a little script to generate boxplots with underlayed violin plots which are both nice ways to visualize skewed distributions like what we have with many quantities / plugins.

As a bit of an explanation, the box-and-whisker plots show a few things: 

```
     Q1-1.5IQR   Q1   median  Q3   Q3+1.5IQR
                  |-----:-----|
  o      |--------|     :     |--------|    o  o
                  |-----:-----|
flier             <----------->            fliers
                       IQR
```

- The median, which is the value for which there are equal number of points on either side, making it fairly robust to outliers (also called Q2, the second quartile, or the 50% quantile)
- Q1 and Q3 are the first and third `quartiles` or the 25% and 75% `quantiles` of the data, basically the range where the central 50% of the data lie
- The three above make a `box` 
- `Whiskers` which show Q1 - 1.5 * IQR (IQR === inter-quartile range === Q3 - Q1) and Q3 + 1.5 * IQR; which is a reasonable limit for non-outlying data
- The outliers themselves as points (`fliers`)

The violin plots are constructed using a kernel density estimate (KDE), which is an algorithm that tries to represent any arbitrary distribution as a linear combination of some kernel functions (in this case Gaussians).
This method gives a fairly faithful representation of the distribution given that the bandwidth (Gaussian sigma) is reasonable.
By default, the bandwidth is found using the `scott` algorithm.

Combined, these two plots give both a faithful representation of the distribution of the data and the salient points about its center, spread, and outliers, all in a compact enough way to fit all the data in one figure.

![image](https://user-images.githubusercontent.com/75646713/163341149-b7918801-146a-494d-94dc-fced87d54d47.png)

The script also prints tables of the statistics (median, mean, and IQR) using `tabulate`, e.g.: 
```
IQR
Plugin              dV0 [%]    dB0 [%]    dB1 [%]      Delta    Epsilon
----------------  ---------  ---------  ---------  ---------  ---------
ABINIT PAW v1.1   0.557751    0.930784   3.25585    5.08886    22.5265
ABINIT NC v0.4    0.271944    0.437255   0.60934    4.45057    13.7312
ABINIT NC v0.5b1  0.227976    0.427039   0.565546   3.61301    12.1875
CASTEP            1.40675     1.33817    1.57738   13.5903     72.9721
CP2K DZVP         2.12597     4.1801     1.72829   22.4181     98.5028
Fleur             0.0388763   0.247219   0.542678   0.412155    1.84864
gpaw              0.961021    1.12111    3.81829   11.6838     46.7687
CASTEP v2         0.643158    0.837275   1.41652    5.99222    31.8812
Quantum ESPRESSO  0.567408    0.635905   0.799235   6.50594    31.6905
VASP recpot       0.694068    2.63534    6.67612    9.84558    42.8472
VASP recpot e700  0.677587    2.13429    1.90525    9.9916     51.9845
```

