### PR TITLE
Consistent colorbar for periodic tables

### DIFF
--- a/acwf_paper_plots/plots/supplementary/periodic_tables_all/generate_all_periodic_table.py
+++ b/acwf_paper_plots/plots/supplementary/periodic_tables_all/generate_all_periodic_table.py
@@ -21,12 +21,20 @@ EXPECTED_SCRIPT_VERSION = ["0.0.3","0.0.4"]
 # Therefore, the UNICODE name has 'per atom' since it is shown in the final plot
 UNICODE_QUANTITY = {'nu': 'ν', 'epsilon': 'ε', 'delta_per_formula_unit': 'Δ per atom', 'delta_per_formula_unit_over_b0': 'Δ/B₀ per atom'}
 EXCELLENT_AGREEMENT_THRESHOLD = {
-    'nu': 0.1, 'epsilon': 0.06,
+    'nu': 0.10, 'epsilon': 0.06,
     'delta_per_formula_unit': 0., # I put zero, it's not used in this script anyway
     'delta_per_formula_unit_over_b0': 0. # I put zero, it's not used in this script anyway
-
+    }
+GOOD_AGREEMENT_THRESHOLD = {
+    'nu': 0.35, 'epsilon': 0.20,
+    'delta_per_formula_unit': 0., # I put zero, it's not used in this script anyway
+    'delta_per_formula_unit_over_b0': 0. # I put zero, it's not used in this script anyway
     }
 PRINT_NON_EXCELLENT = False
+
+# As found in the paper, nu and eps can be roughly related via just a multiplication: nu=NU_EPS_FACTOR*eps
+# Use this to set a consistent maximum colorbar value
+NU_EPS_FACTOR=1.704
 
 ## IN ORDER TO PLOT ALL
 # Whether to use
@@ -34,7 +42,7 @@ USE_AE_AVERAGE_AS_REFERENCE = True
 # The following line is ony used if USE_AE_AVERAGE_AS_REFERENCE is False
 REFERENCE_CODE_LABEL = None
 SET_MAX_SCALE_DICT = {}
-ONLY_CODES = None
+ONLY_CODES = None #["ABINIT@PW|PseudoDojo-v0.5", "BigDFT@DW|HGH-K(Valence)"]
 
 # ## IN ORDER TO PLOT ONLY THE AE COMPARISON
 # # Whether to use
@@ -87,14 +95,11 @@ quantity_for_comparison_map = {
     "abs_V0_rel_diff": abs_V0_rel_diff,
     "abs_B0_rel_diff": abs_B0_rel_diff,
     "abs_B1_rel_diff": abs_B1_rel_diff,            
-    f"nu": qc.nu,
+    "nu": qc.nu,
     "epsilon": qc.epsilon
 }
 
-
-def plot_periodic_table(SET_NAME, QUANTITY):
-    SET_MAX_SCALE = SET_MAX_SCALE_DICT.get(QUANTITY, None)
-    prefactor = PREFACTOR_DICT.get(QUANTITY, 1.)
+def load_data(SET_NAME):
 
     DATA_FOLDER = "../../../code-data"
     with open(os.path.join(DATA_FOLDER, "labels.json")) as fhandle:
@@ -119,7 +124,6 @@ def plot_periodic_table(SET_NAME, QUANTITY):
         print(f"No data found for the all-electron dataset (set '{SET_NAME}'), it is the reference and must be present")
         sys.exit(1)
 
-
     code_results = {}
     short_labels = {}
     for code_label in labels_data['methods-main']:
@@ -135,81 +139,443 @@ def plot_periodic_table(SET_NAME, QUANTITY):
                     )
                 #code_results.pop(label)
 
-    for plugin, plugin_data in code_results.items():
+    loaded_data = {
+        "code_results": code_results,
+        "short_labels": short_labels,
+        "reference_short_label": reference_short_label,
+        "compare_plugin_data": compare_plugin_data
+    }
 
-        print(f"Using data for method '{plugin}' (set '{SET_NAME}') compared with {reference_short_label}.")
+    return loaded_data
 
 
-        all_systems = set(plugin_data['eos_data'].keys())
-        all_systems = set(plugin_data['BM_fit_data'].keys())
-        #all_systems.update(compare_plugin_data['BM_fit_data'].keys())
+def calculate_quantities(plugin_data, compare_plugin_data, QUANTITY):
+    prefactor = PREFACTOR_DICT.get(QUANTITY, 1.)
 
-        collect = {
-            "X/Diamond" : {"elements": [], "values": []},
-            "X/FCC" : {"elements": [], "values": []},
-            "X/BCC" : {"elements": [], "values": []},
-            "X/SC" : {"elements": [], "values": []},
-            "X2O3" : {"elements": [], "values": []},
-            "X2O5" : {"elements": [], "values": []},
-            "XO2" : {"elements": [], "values": []},
-            "XO3" : {"elements": [], "values": []},
-            "XO" : {"elements": [], "values": []},
-            "X2O" : {"elements": [], "values": []}
-            }
+    all_systems = set(plugin_data['eos_data'].keys())
+    all_systems = set(plugin_data['BM_fit_data'].keys())
+    #all_systems.update(compare_plugin_data['BM_fit_data'].keys())
 
-        progress_bar = tqdm.tqdm(sorted(all_systems))
-        for element_and_configuration in progress_bar:
-            progress_bar.set_description(f"{element_and_configuration:12s}")
-            progress_bar.refresh()
+    collect = {
+        "X/Diamond" : {"elements": [], "values": []},
+        "X/FCC" : {"elements": [], "values": []},
+        "X/BCC" : {"elements": [], "values": []},
+        "X/SC" : {"elements": [], "values": []},
+        "X2O3" : {"elements": [], "values": []},
+        "X2O5" : {"elements": [], "values": []},
+        "XO2" : {"elements": [], "values": []},
+        "XO3" : {"elements": [], "values": []},
+        "XO" : {"elements": [], "values": []},
+        "X2O" : {"elements": [], "values": []}
+        }
 
-            element, configuration = element_and_configuration.split('-')
-            # Get the data for the reference plugin
-            ref_BM_fit_data = plugin_data['BM_fit_data'][f'{element}-{configuration}']
+    progress_bar = tqdm.tqdm(sorted(all_systems))
+    for element_and_configuration in progress_bar:
+        progress_bar.set_description(f"{element_and_configuration:12s}")
+        progress_bar.refresh()
+
+        element, configuration = element_and_configuration.split('-')
+        # Get the data for the reference plugin
+        ref_BM_fit_data = plugin_data['BM_fit_data'][f'{element}-{configuration}']
+    
+        if ref_BM_fit_data is None:
+            continue
+    
+        scaling_factor_ref = qc.get_volume_scaling_to_formula_unit(
+                plugin_data['num_atoms_in_sim_cell'][f'{element}-{configuration}'],
+                element, configuration
+            )
+
+        # Here I normalize quantities, so that they are now per atom and not per formula unit!
+        # This does not change anything for epsilon and nu, but changes for delta
+        V0=ref_BM_fit_data['min_volume']/scaling_factor_ref
+        B0=ref_BM_fit_data['bulk_modulus_ev_ang3']
+        B01=ref_BM_fit_data['bulk_deriv']
+
+        # Get the data for the compare_with plugin, if specified (and if the EOS worked for the 
+        # reference plugin, otherwise we don't know which E0 to use)
+        try:
+            compare_BM_fit_data = compare_plugin_data['BM_fit_data'][f'{element}-{configuration}']
+            if compare_BM_fit_data is None:
+                # No fitting data in the plugin to compare with.
+                # Raise this exception that is catched one line below, so
+                # it will set `compare_eos_fit_energy` to None.
+                raise KeyError                    
+        except KeyError:
+            # Set to None if fit data is missing (if we are here, the EOS points
+            # are there, so it means that the fit failed). I will still plot the
+            # points
+            continue
+
+        scaling_factor_comp = qc.get_volume_scaling_to_formula_unit(
+                compare_plugin_data['num_atoms_in_sim_cell'][f'{element}-{configuration}'],
+                element, configuration
+            )
+
+        # Here I normalize quantities, so that they are now per atom and not per formula unit!
+        # This does not change anything for epsilon and nu, but changes for delta
+        CV0=compare_BM_fit_data['min_volume']/scaling_factor_comp
+        CB0=compare_BM_fit_data['bulk_modulus_ev_ang3']
+        CB01=compare_BM_fit_data['bulk_deriv']
+
+        quant = quantity_for_comparison_map[QUANTITY](V0,B0,B01,CV0,CB0,CB01,prefactor,DEFAULT_wb0,DEFAULT_wb1)
+
+        collect[configuration]["values"].append(quant)
+        collect[configuration]["elements"].append(element)
+
+    return collect
+
+
+
+def create_periodic_table(collect, list_confs, short_labels, plugin, reference_short_label, unaries, SET_MAX_SCALE):
+
+    print(SET_MAX_SCALE)
+
+    width = 1050
+    cmap = "plasma"
+    alpha = 0.7
+    extended = True
+    log_scale = False
+    cbar_height = None
+    cbar_standoff = 12
+    cbar_fontsize = 14
+    blank_color = "#c4c4c4"
+    under_value = None
+    under_color = "#140F0E"
+    over_value = None
+    over_color = "#140F0E"
+    special_elements = None
+    special_color = "#6F3023"
+
+    options.mode.chained_assignment = None
+
+    # Assign color palette based on input argument
+    if cmap == "plasma":
+        cmap = plasma
+        bokeh_palette = "Plasma256"
+    elif cmap == "magma":
+        cmap = magma
+        bokeh_palette = "Magma256"
+    elif cmap == "viridis":
+        cmap = viridis
+        bokeh_palette = "Viridis256"
+    elif cmap == "inferno":
+        cmap = inferno
+        bokeh_palette = "Inferno256"
+    else:
+        raise ValueError("Unknown color map")
+
+    # Define number of and groups
+    period_label = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    group_range = [x for x in range(1, 19)]
+
+    #We "fake" that La-Yb has period 9 and group from 5 to 18, also that
+    #Th-Lr has period 10 and group from 5 to 18. It is just to place them in
+    #the correct point in the chart.
+    count=0
+    for i in range(56, 70):
+        elements.period[i] = 9
+        elements.group[i] = count + 4
+        count += 1
+
+    count = 0
+    for i in range(88, 102):
+        elements.period[i] = 10
+        elements.group[i] = count + 4
+        count += 1
+
+    per = [int(i) for i in elements["period"]]
+    grou = [int(i) for i in elements["group"]]
+
+    # I put a large (for min) and small (default for empty sets)
+    min_data = min([min(collect[i]["values"], default=100) for i in list_confs])
+    max_data = max([max(collect[i]["values"], default=0) for i in list_confs])
+
+    # If it's reallly all empty
+    if min_data > max_data:
+        min_data = max_data
+
+    color_list={}
+
+    if SET_MAX_SCALE:
+        high = SET_MAX_SCALE
+    else:
+        high = max_data
+
+    # EXPORT JSON: a dictionary with key = element+config, value = measure
+    data_to_export = {}
+    for conf in list_confs:
         
-            if ref_BM_fit_data is None:
-                continue
-        
-            scaling_factor_ref = qc.get_volume_scaling_to_formula_unit(
-                    plugin_data['num_atoms_in_sim_cell'][f'{element}-{configuration}'],
-                    element, configuration
-                )
+        data_to_export.update(dict(zip(
+            (f'{element}-{conf}' for element in collect[conf]["elements"]),
+            collect[conf]["values"])))
+    with open(f"{QUANTITY}-{SET_NAME}-{short_labels[plugin].replace(' ', '_')}-vs-{reference_short_label.replace(' ', '_')}.json", 'w') as fhandle:
+        json.dump(data_to_export, fhandle)
 
-            # Here I normalize quantities, so that they are now per atom and not per formula unit!
-            # This does not change anything for epsilon and nu, but changes for delta
-            V0=ref_BM_fit_data['min_volume']/scaling_factor_ref
-            B0=ref_BM_fit_data['bulk_modulus_ev_ang3']
-            B01=ref_BM_fit_data['bulk_deriv']
+    non_excellent = []
+    tot_count = 0
+    for conf in list_confs:
+        data_elements = collect[conf]["elements"]
+        tot_count += len(data_elements)
+        data = collect[conf]["values"]
 
-            # Get the data for the compare_with plugin, if specified (and if the EOS worked for the 
-            # reference plugin, otherwise we don't know which E0 to use)
-            try:
-                compare_BM_fit_data = compare_plugin_data['BM_fit_data'][f'{element}-{configuration}']
-                if compare_BM_fit_data is None:
-                    # No fitting data in the plugin to compare with.
-                    # Raise this exception that is catched one line below, so
-                    # it will set `compare_eos_fit_energy` to None.
-                    raise KeyError                    
-            except KeyError:
-                # Set to None if fit data is missing (if we are here, the EOS points
-                # are there, so it means that the fit failed). I will still plot the
-                # points
-                continue
+        if len(data) != len(data_elements):
+            raise ValueError("Unequal number of atomic elements and data points")
 
-            scaling_factor_comp = qc.get_volume_scaling_to_formula_unit(
-                    compare_plugin_data['num_atoms_in_sim_cell'][f'{element}-{configuration}'],
-                    element, configuration
-                )
+        # Define matplotlib and bokeh color map
+        if log_scale:
+            for datum in data:
+                if datum < 0:
+                    raise ValueError(
+                        f"Entry for element {datum} is negative but log-scale is selected"
+                    )
+            color_mapper = LogColorMapper(
+                palette=bokeh_palette, low=min_data, high=high
+            )
+            norm = LogNorm(vmin=min_data, vmax=high)
+        else:
+            low = 0.
+            color_mapper = LinearColorMapper(
+                palette=bokeh_palette, low=low, high=high
+            )
+            norm = Normalize(vmin=low, vmax=high)
+            
+        color_scale = ScalarMappable(norm=norm, cmap=cmap).to_rgba(data, alpha=None)
 
-            # Here I normalize quantities, so that they are now per atom and not per formula unit!
-            # This does not change anything for epsilon and nu, but changes for delta
-            CV0=compare_BM_fit_data['min_volume']/scaling_factor_comp
-            CB0=compare_BM_fit_data['bulk_modulus_ev_ang3']
-            CB01=compare_BM_fit_data['bulk_deriv']
+        # Set blank color
+        color_list[conf] = [blank_color] * len(elements)
 
-            quant = quantity_for_comparison_map[QUANTITY](V0,B0,B01,CV0,CB0,CB01,prefactor,DEFAULT_wb0,DEFAULT_wb1)
 
-            collect[configuration]["values"].append(quant)
-            collect[configuration]["elements"].append(element)
+        # Compare elements in dataset with elements in periodic table
+        for i, data_element in enumerate(data_elements):
+            element_entry = elements.symbol[
+                elements.symbol.str.lower() == data_element.lower()
+            ]
+            if element_entry.empty == False:
+                element_index = element_entry.index[0]
+            else:
+                warnings.warn("Invalid chemical symbol: " + data_element)
+            if color_list[conf][element_index] != blank_color:
+                warnings.warn("Multiple entries for element " + data_element)
+            elif under_value is not None and data[i] <= under_value:
+                color_list[conf][element_index] = under_color
+            elif over_value is not None and data[i] >= over_value:
+                color_list[conf][element_index] = over_color
+            else:
+                color_list[conf][element_index] = to_hex(color_scale[i])
+            if data[i] > high:
+                print(f"** WARNING! {data_element}-{conf} has value {data[i]} > max of colorbar ({high})")
+            if data[i] > EXCELLENT_AGREEMENT_THRESHOLD[QUANTITY]:
+                non_excellent.append(f"{data_element}({conf})")
+    if PRINT_NON_EXCELLENT:
+        print(f">>> Non excellent agreement ({QUANTITY} >= {EXCELLENT_AGREEMENT_THRESHOLD[QUANTITY]}) for {len(non_excellent)}/{tot_count} systems: {','.join(non_excellent)}")
+
+
+    if unaries:
+        # Define figure properties for visualizing data
+        source = ColumnDataSource(
+            data=dict(
+                group=grou,
+                period=per,
+                top=[i-0.45 for i in per],
+                bottom=[i+0.45 for i in per],
+                left=[i-0.45 for i in grou],
+                right=[i+0.45 for i in grou],
+                sym=elements["symbol"],
+                atomic_number=elements["atomic number"],
+                type_color_dia=color_list["X/Diamond"],
+                type_color_sc=color_list["X/SC"],
+                type_color_bcc=color_list["X/BCC"],
+                type_color_fcc=color_list["X/FCC"],
+            )
+        )
+
+        # Plot the periodic table
+        p = figure(x_range=[0,19], y_range=[11,0], tools="save")
+        p.toolbar.logo = None
+        p.toolbar.tools = []
+        p.toolbar_location = None
+        p.plot_width = width
+        p.outline_line_color = None
+        p.background_fill_color = None
+        p.border_fill_color = None
+        p.toolbar_location = "above"
+        p.quad(left="left", right="group", top="period", bottom="bottom", source=source, alpha=alpha, color="type_color_dia")
+        p.quad(left="left", right="group", top="top", bottom="period", source=source, alpha=alpha, color="type_color_sc")
+        p.quad(left="group", right="right", top="period", bottom="bottom", source=source, alpha=alpha, color="type_color_bcc")
+        p.quad(left="group", right="right", top="top", bottom="period", source=source, alpha=alpha, color="type_color_fcc")
+        p.axis.visible = False
+
+        #The reference block
+        p.quad(left=5,right=6.5,bottom=0,top=1.5,fill_color="white")
+        p.quad(left=5,right=6.5,bottom=1.5,top=3,fill_color="white")
+        p.quad(left=6.5,right=8,bottom=0,top=1.5,fill_color="white")
+        p.quad(left=6.5,right=8,bottom=1.5,top=3,fill_color="white")
+        xx=[5.75,5.75,7.25,7.25]
+        yy=[0.75,2.25,0.75,2.25]
+        text=["SC","Diamond","FCC","BCC"]
+        sou = ColumnDataSource(dict(x=xx, y=yy, text=text))
+        p.text(
+            x="x",
+            y="y",
+            text="text",
+            source=sou,
+            text_font_style="bold",
+            text_font_size="17pt",
+            text_align= "center",
+            text_baseline= "middle",
+            angle=-45,
+            angle_units="grad"
+            )
+
+    else:
+        # Define figure properties for visualizing data
+        source = ColumnDataSource(
+            data=dict(
+                group=grou,
+                period=per,
+                top=[i-0.45 for i in per],
+                bottom=[i+0.45 for i in per],
+                left=[i-0.45 for i in grou],
+                right=[i+0.45 for i in grou],
+                midup=[i-0.15 for i in per],
+                middown=[i+0.15 for i in per],
+                sym=elements["symbol"],
+                atomic_number=elements["atomic number"],
+                type_color_X2O3=color_list["X2O3"],
+                type_color_X2O5=color_list["X2O5"],
+                type_color_X2O=color_list["X2O"],
+                type_color_XO2=color_list["XO2"],
+                type_color_XO3=color_list["XO3"],
+                type_color_XO=color_list["XO"],
+            )
+        )
+
+        # Plot the periodic table
+        p = figure(x_range=[0,19], y_range=[11,0], tools="save")
+        p.toolbar.logo = None
+        p.toolbar.tools = []
+        p.toolbar_location = None
+        p.plot_width = width
+        p.outline_line_color = None
+        p.background_fill_color = None
+        p.border_fill_color = None
+        p.toolbar_location = "above"
+        p.quad(left="left", right="group", top="top", bottom="midup", source=source, alpha=alpha, color="type_color_X2O3")
+        p.quad(left="left", right="group", top="midup", bottom="middown", source=source, alpha=alpha, color="type_color_X2O")
+        p.quad(left="left", right="group", top="middown", bottom="bottom", source=source, alpha=alpha, color="type_color_XO3")
+        p.quad(left="group", right="right", top="top", bottom="midup", source=source, alpha=alpha, color="type_color_X2O5")
+        p.quad(left="group", right="right", top="midup", bottom="middown", source=source, alpha=alpha, color="type_color_XO2")
+        p.quad(left="group", right="right", top="middown", bottom="bottom", source=source, alpha=alpha, color="type_color_XO")
+        p.axis.visible = False
+
+        #The reference block
+        p.quad(left=5,right=6.5,bottom=0,top=1,fill_color="white")
+        p.quad(left=5,right=6.5,bottom=1,top=2,fill_color="white")
+        p.quad(left=5,right=6.5,bottom=2,top=3,fill_color="white")
+        p.quad(left=6.5,right=8,bottom=0,top=1,fill_color="white")
+        p.quad(left=6.5,right=8,bottom=1,top=2,fill_color="white")
+        p.quad(left=6.5,right=8,bottom=2,top=3,fill_color="white")
+        xx=[5.75,5.75,5.75,7.25,7.25,7.25]
+        yy=[0.5,1.5,2.5,0.5,1.5,2.5]
+        text=["X2O3","X2O","XO3","X2O5","XO2","XO"]
+        sou = ColumnDataSource(dict(x=xx, y=yy, text=text))
+        p.text(
+            x="x",
+            y="y",
+            text="text",
+            source=sou,
+            text_font_style="bold",
+            text_font_size="17pt",
+            text_align= "center",
+            text_baseline= "middle",
+            )
+
+
+    #Add element name
+    text_props = {
+        "source": source,
+        "angle": 0,
+        "color": "black",
+        "text_align": "center",
+        "text_baseline": "middle",
+    }
+    #x = dodge("group", -0.4, range=p.x_range)
+    #y = dodge("period", 0.3, range=p.y_range)
+    p.text(
+        x="group",
+        y="period",
+        text="sym",
+        text_font_style="bold",
+        text_font_size="16pt",
+        **text_props,
+    )
+    #p.text(x=x, y=y, text="atomic_number", text_font_size="11pt", **text_props)
+
+    reference_label = 'all-electron average' if USE_AE_AVERAGE_AS_REFERENCE else REFERENCE_CODE_LABEL
+    p.title = f"{UNICODE_QUANTITY[QUANTITY]} for {plugin} vs. {reference_label}"
+    p.title.text_font_size = '16pt'
+
+    color_bar = ColorBar(
+        color_mapper=color_mapper,
+        ticker=BasicTicker(desired_num_ticks=10),
+        border_line_color=None,
+        label_standoff=cbar_standoff,
+        location=(0, 0),
+        orientation="vertical",
+        scale_alpha=alpha,
+        major_label_text_font_size=f"{cbar_fontsize}pt",
+    )
+
+    if cbar_height is not None:
+        color_bar.height = cbar_height
+
+    p.add_layout(color_bar, "right")
+    p.grid.grid_line_color = None
+
+        # Open in a browser
+    if SHOW_IN_BROWSER:
+        output_file("periodic-table-plot.html")
+        show_(p)
+    else:
+        try:
+            export_png(p, filename=f"periodic-table-{SET_NAME}-{short_labels[plugin].replace(' ', '_')}-vs-{reference_short_label.replace(' ', '_')}-{QUANTITY}.png")
+        except RuntimeError as exc:
+            msg = str(exc)
+            msg = f"""
+
+ERROR GENERATING THE IMAGE!
+The original error message was:
+{msg}
+
+Please check the following:
+- Bokeh instructions here: https://docs.bokeh.org/en/latest/docs/user_guide/export.html#additional-dependencies
+- That you installed the requirements.txt file, and in particular that you installed
+`pip install selenium chromedriver-binary`
+(to use with Chrome)
+- that you have a recent version of Chrome
+- that you downloaded from https://chromedriver.chromium.org/ and put in your PATH
+the chromedriver executable for the *SAME* version of Chrome that you have
+(note that Chrome typically self-updates, so check even if this script
+used to work, check that now Chrome is not more recent than the chromedriver you had installed;
+in this case udpate it).
+"""
+            raise RuntimeError(msg)
+
+
+
+
+def plot_periodic_tables(SET_NAME, QUANTITY, nu_colorbar_max, master_data_dict):
+
+
+    ld = master_data_dict[SET_NAME]["loaded_data"]
+
+    for plugin, plugin_data in ld["code_results"].items():
+
+        print(f"Using data for method '{plugin}' (set '{SET_NAME}') compared with {ld['reference_short_label']}.")
+
+
+        collect = master_data_dict[SET_NAME]["calculated_quantities"][QUANTITY][plugin]
 
         # Way to decide whether is a unaries or an oxides set is a bit fragile.
         if collect["X/Diamond"]["values"]:
@@ -219,343 +585,92 @@ def plot_periodic_table(SET_NAME, QUANTITY):
             unaries = False
             list_confs = ["X2O3","X2O5","X2O","XO2","XO3","XO"]
 
-        width = 1050
-        cmap = "plasma"
-        alpha = 0.7
-        extended = True
-        log_scale = False
-        cbar_height = None
-        cbar_standoff = 12
-        cbar_fontsize = 14
-        blank_color = "#c4c4c4"
-        under_value = None
-        under_color = "#140F0E"
-        over_value = None
-        over_color = "#140F0E"
-        special_elements = None
-        special_color = "#6F3023"
+        SET_MAX_SCALE = SET_MAX_SCALE_DICT.get(QUANTITY, None)
 
-        options.mode.chained_assignment = None
+        if SET_MAX_SCALE == None:
+            # Unless user defined a max scale, read a consistent one for NU/EPS from nu_colorbar_max
+            if QUANTITY == "nu":
+                SET_MAX_SCALE = nu_colorbar_max[plugin]
+            elif QUANTITY == "epsilon":
+                SET_MAX_SCALE = nu_colorbar_max[plugin] / NU_EPS_FACTOR
 
-        # Assign color palette based on input argument
-        if cmap == "plasma":
-            cmap = plasma
-            bokeh_palette = "Plasma256"
-        elif cmap == "magma":
-            cmap = magma
-            bokeh_palette = "Magma256"
-        elif cmap == "viridis":
-            cmap = viridis
-            bokeh_palette = "Viridis256"
-        elif cmap == "inferno":
-            cmap = inferno
-            bokeh_palette = "Inferno256"
-        else:
-            raise ValueError("Unknown color map")
+        create_periodic_table(collect, list_confs, ld["short_labels"], plugin, ld["reference_short_label"], unaries, SET_MAX_SCALE)
 
-        # Define number of and groups
-        period_label = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        group_range = [x for x in range(1, 19)]
 
-        #We "fake" that La-Yb has period 9 and group from 5 to 18, also that
-        #Th-Lr has period 10 and group from 5 to 18. It is just to place them in
-        #the correct point in the chart.
-        count=0
-        for i in range(56, 70):
-            elements.period[i] = 9
-            elements.group[i] = count + 4
-            count += 1
+def find_code_nu_colorbar_maximums(master_data_dict):
+    """
+    For every code, we plot 4 periodic tables: unaries and oxides for nu and epsilon.
+    Set the maximum color scale such that
+    * the same quantity always has the same color maximum within the code
+    * the colorbar maximum follows the relation found in the paper of nu=NU_EPS_FACTOR*eps
+    """
 
-        count = 0
-        for i in range(88, 102):
-            elements.period[i] = 10
-            elements.group[i] = count + 4
-            count += 1
+    nu_colorbar_max = {}
 
-        per = [int(i) for i in elements["period"]]
-        grou = [int(i) for i in elements["group"]]
+    for SET_NAME in ['unaries', 'oxides']:
 
-        # I put a large (for min) and small (default for empty sets)
-        min_data = min([min(collect[i]["values"], default=100) for i in list_confs])
-        max_data = max([max(collect[i]["values"], default=0) for i in list_confs])
+        ld = master_data_dict[SET_NAME]["loaded_data"]
 
-        # If it's reallly all empty
-        if min_data > max_data:
-            min_data = max_data
+        for QUANTITY in ['epsilon', 'nu']:
 
-        color_list={}
+            for plugin, plugin_data in ld["code_results"].items():
 
-        if SET_MAX_SCALE:
-            high = SET_MAX_SCALE
-        else:
-            high = max_data
-
-        # EXPORT JSON: a dictionary with key = element+config, value = measure
-        data_to_export = {}
-        for conf in list_confs:
-            
-            data_to_export.update(dict(zip(
-                (f'{element}-{conf}' for element in collect[conf]["elements"]),
-                collect[conf]["values"])))
-        with open(f"{QUANTITY}-{SET_NAME}-{short_labels[plugin].replace(' ', '_')}-vs-{reference_short_label.replace(' ', '_')}.json", 'w') as fhandle:
-            json.dump(data_to_export, fhandle)
-
-        non_excellent = []
-        tot_count = 0
-        for conf in list_confs:
-            data_elements = collect[conf]["elements"]
-            tot_count += len(data_elements)
-            data = collect[conf]["values"]
-
-            if len(data) != len(data_elements):
-                raise ValueError("Unequal number of atomic elements and data points")
-
-            # Define matplotlib and bokeh color map
-            if log_scale:
-                for datum in data:
-                    if datum < 0:
-                        raise ValueError(
-                            f"Entry for element {datum} is negative but log-scale is selected"
-                        )
-                color_mapper = LogColorMapper(
-                    palette=bokeh_palette, low=min_data, high=high
-                )
-                norm = LogNorm(vmin=min_data, vmax=high)
-            else:
-                low = 0.
-                color_mapper = LinearColorMapper(
-                    palette=bokeh_palette, low=low, high=high
-                )
-                norm = Normalize(vmin=low, vmax=high)
+                if plugin not in nu_colorbar_max:
+                    nu_colorbar_max[plugin] = 0.0
                 
-            color_scale = ScalarMappable(norm=norm, cmap=cmap).to_rgba(data, alpha=None)
+                collect = master_data_dict[SET_NAME]["calculated_quantities"][QUANTITY][plugin]
 
-            # Set blank color
-            color_list[conf] = [blank_color] * len(elements)
+                # find the maximum in all of the collected data
 
+                for configuration, conf_data in collect.items():
 
-            # Compare elements in dataset with elements in periodic table
-            for i, data_element in enumerate(data_elements):
-                element_entry = elements.symbol[
-                    elements.symbol.str.lower() == data_element.lower()
-                ]
-                if element_entry.empty == False:
-                    element_index = element_entry.index[0]
-                else:
-                    warnings.warn("Invalid chemical symbol: " + data_element)
-                if color_list[conf][element_index] != blank_color:
-                    warnings.warn("Multiple entries for element " + data_element)
-                elif under_value is not None and data[i] <= under_value:
-                    color_list[conf][element_index] = under_color
-                elif over_value is not None and data[i] >= over_value:
-                    color_list[conf][element_index] = over_color
-                else:
-                    color_list[conf][element_index] = to_hex(color_scale[i])
-                if data[i] > high:
-                    print(f"** WARNING! {data_element}-{conf} has value {data[i]} > max of colorbar ({high})")
-                if data[i] > EXCELLENT_AGREEMENT_THRESHOLD[QUANTITY]:
-                    non_excellent.append(f"{data_element}({conf})")
-        if PRINT_NON_EXCELLENT:
-            print(f">>> Non excellent agreement ({QUANTITY} >= {EXCELLENT_AGREEMENT_THRESHOLD[QUANTITY]}) for {len(non_excellent)}/{tot_count} systems: {','.join(non_excellent)}")
+                    if len(conf_data['values']) == 0:
+                        continue
 
+                    current_conf_max_val = max(conf_data['values'])
+                    
+                    if QUANTITY == "nu":
+                        nu_colorbar_max[plugin] = max(nu_colorbar_max[plugin], current_conf_max_val)
+                    elif QUANTITY == "eps":
 
-        if unaries:
-            # Define figure properties for visualizing data
-            source = ColumnDataSource(
-                data=dict(
-                    group=grou,
-                    period=per,
-                    top=[i-0.45 for i in per],
-                    bottom=[i+0.45 for i in per],
-                    left=[i-0.45 for i in grou],
-                    right=[i+0.45 for i in grou],
-                    sym=elements["symbol"],
-                    atomic_number=elements["atomic number"],
-                    type_color_dia=color_list["X/Diamond"],
-                    type_color_sc=color_list["X/SC"],
-                    type_color_bcc=color_list["X/BCC"],
-                    type_color_fcc=color_list["X/FCC"],
-                )
-            )
+                        # convert current max to eps
+                        current_eps_max = NU_EPS_FACTOR*nu_colorbar_max[plugin]
+                        # check which value is higher and convert back to nu
+                        nu_colorbar_max[plugin] = max(current_eps_max, current_conf_max_val) / NU_EPS_FACTOR
+    
+    print(nu_colorbar_max)
 
-            # Plot the periodic table
-            p = figure(x_range=[0,19], y_range=[11,0], tools="save")
-            p.toolbar.logo = None
-            p.toolbar.tools = []
-            p.toolbar_location = None
-            p.plot_width = width
-            p.outline_line_color = None
-            p.background_fill_color = None
-            p.border_fill_color = None
-            p.toolbar_location = "above"
-            p.quad(left="left", right="group", top="period", bottom="bottom", source=source, alpha=alpha, color="type_color_dia")
-            p.quad(left="left", right="group", top="top", bottom="period", source=source, alpha=alpha, color="type_color_sc")
-            p.quad(left="group", right="right", top="period", bottom="bottom", source=source, alpha=alpha, color="type_color_bcc")
-            p.quad(left="group", right="right", top="top", bottom="period", source=source, alpha=alpha, color="type_color_fcc")
-            p.axis.visible = False
-
-            #The reference block
-            p.quad(left=5,right=6.5,bottom=0,top=1.5,fill_color="white")
-            p.quad(left=5,right=6.5,bottom=1.5,top=3,fill_color="white")
-            p.quad(left=6.5,right=8,bottom=0,top=1.5,fill_color="white")
-            p.quad(left=6.5,right=8,bottom=1.5,top=3,fill_color="white")
-            xx=[5.75,5.75,7.25,7.25]
-            yy=[0.75,2.25,0.75,2.25]
-            text=["SC","Diamond","FCC","BCC"]
-            sou = ColumnDataSource(dict(x=xx, y=yy, text=text))
-            p.text(
-                x="x",
-                y="y",
-                text="text",
-                source=sou,
-                text_font_style="bold",
-                text_font_size="17pt",
-                text_align= "center",
-                text_baseline= "middle",
-                angle=-45,
-                angle_units="grad"
-                )
-
-        else:
-            # Define figure properties for visualizing data
-            source = ColumnDataSource(
-                data=dict(
-                    group=grou,
-                    period=per,
-                    top=[i-0.45 for i in per],
-                    bottom=[i+0.45 for i in per],
-                    left=[i-0.45 for i in grou],
-                    right=[i+0.45 for i in grou],
-                    midup=[i-0.15 for i in per],
-                    middown=[i+0.15 for i in per],
-                    sym=elements["symbol"],
-                    atomic_number=elements["atomic number"],
-                    type_color_X2O3=color_list["X2O3"],
-                    type_color_X2O5=color_list["X2O5"],
-                    type_color_X2O=color_list["X2O"],
-                    type_color_XO2=color_list["XO2"],
-                    type_color_XO3=color_list["XO3"],
-                    type_color_XO=color_list["XO"],
-                )
-            )
-
-            # Plot the periodic table
-            p = figure(x_range=[0,19], y_range=[11,0], tools="save")
-            p.toolbar.logo = None
-            p.toolbar.tools = []
-            p.toolbar_location = None
-            p.plot_width = width
-            p.outline_line_color = None
-            p.background_fill_color = None
-            p.border_fill_color = None
-            p.toolbar_location = "above"
-            p.quad(left="left", right="group", top="top", bottom="midup", source=source, alpha=alpha, color="type_color_X2O3")
-            p.quad(left="left", right="group", top="midup", bottom="middown", source=source, alpha=alpha, color="type_color_X2O")
-            p.quad(left="left", right="group", top="middown", bottom="bottom", source=source, alpha=alpha, color="type_color_XO3")
-            p.quad(left="group", right="right", top="top", bottom="midup", source=source, alpha=alpha, color="type_color_X2O5")
-            p.quad(left="group", right="right", top="midup", bottom="middown", source=source, alpha=alpha, color="type_color_XO2")
-            p.quad(left="group", right="right", top="middown", bottom="bottom", source=source, alpha=alpha, color="type_color_XO")
-            p.axis.visible = False
-
-            #The reference block
-            p.quad(left=5,right=6.5,bottom=0,top=1,fill_color="white")
-            p.quad(left=5,right=6.5,bottom=1,top=2,fill_color="white")
-            p.quad(left=5,right=6.5,bottom=2,top=3,fill_color="white")
-            p.quad(left=6.5,right=8,bottom=0,top=1,fill_color="white")
-            p.quad(left=6.5,right=8,bottom=1,top=2,fill_color="white")
-            p.quad(left=6.5,right=8,bottom=2,top=3,fill_color="white")
-            xx=[5.75,5.75,5.75,7.25,7.25,7.25]
-            yy=[0.5,1.5,2.5,0.5,1.5,2.5]
-            text=["X2O3","X2O","XO3","X2O5","XO2","XO"]
-            sou = ColumnDataSource(dict(x=xx, y=yy, text=text))
-            p.text(
-                x="x",
-                y="y",
-                text="text",
-                source=sou,
-                text_font_style="bold",
-                text_font_size="17pt",
-                text_align= "center",
-                text_baseline= "middle",
-                )
-
-
-        #Add element name
-        text_props = {
-            "source": source,
-            "angle": 0,
-            "color": "black",
-            "text_align": "center",
-            "text_baseline": "middle",
-        }
-        #x = dodge("group", -0.4, range=p.x_range)
-        #y = dodge("period", 0.3, range=p.y_range)
-        p.text(
-            x="group",
-            y="period",
-            text="sym",
-            text_font_style="bold",
-            text_font_size="16pt",
-            **text_props,
-        )
-        #p.text(x=x, y=y, text="atomic_number", text_font_size="11pt", **text_props)
-
-        reference_label = 'all-electron average' if USE_AE_AVERAGE_AS_REFERENCE else REFERENCE_CODE_LABEL
-        p.title = f"{UNICODE_QUANTITY[QUANTITY]} for {plugin} vs. {reference_label}"
-        p.title.text_font_size = '16pt'
-
-        color_bar = ColorBar(
-            color_mapper=color_mapper,
-            ticker=BasicTicker(desired_num_ticks=10),
-            border_line_color=None,
-            label_standoff=cbar_standoff,
-            location=(0, 0),
-            orientation="vertical",
-            scale_alpha=alpha,
-            major_label_text_font_size=f"{cbar_fontsize}pt",
-        )
-
-        if cbar_height is not None:
-            color_bar.height = cbar_height
-
-        p.add_layout(color_bar, "right")
-        p.grid.grid_line_color = None
-
-         # Open in a browser
-        if SHOW_IN_BROWSER:
-            output_file("periodic-table-plot.html")
-            show_(p)
-        else:
-            try:
-                export_png(p, filename=f"periodic-table-{SET_NAME}-{short_labels[plugin].replace(' ', '_')}-vs-{reference_short_label.replace(' ', '_')}-{QUANTITY}.png")
-            except RuntimeError as exc:
-                msg = str(exc)
-                msg = f"""
-
-ERROR GENERATING THE IMAGE!
-The original error message was:
-{msg}
-
-Please check the following:
-- Bokeh instructions here: https://docs.bokeh.org/en/latest/docs/user_guide/export.html#additional-dependencies
-- That you installed the requirements.txt file, and in particular that you installed
-  `pip install selenium chromedriver-binary`
-  (to use with Chrome)
-- that you have a recent version of Chrome
-- that you downloaded from https://chromedriver.chromium.org/ and put in your PATH
-  the chromedriver executable for the *SAME* version of Chrome that you have
-  (note that Chrome typically self-updates, so check even if this script
-  used to work, check that now Chrome is not more recent than the chromedriver you had installed;
-  in this case udpate it).
-"""
-                raise RuntimeError(msg)
-
-
+    return nu_colorbar_max
+    
 
 if __name__ == "__main__":
-    
-    for SET_NAME in ['unaries', 'oxides']:
-        for QUANTITY in [
-            'epsilon', 'nu', 'delta_per_formula_unit', 
-            'delta_per_formula_unit_over_b0']:
-            plot_periodic_table(SET_NAME, QUANTITY)
+
+    SET_NAMES = ['unaries', 'oxides']
+    #QUANTITIES = ['epsilon', 'nu', 'delta_per_formula_unit', 'delta_per_formula_unit_over_b0']
+    QUANTITIES = ['epsilon', 'nu']
+
+    master_data_dict = {}
+
+    for SET_NAME in SET_NAMES:
+        ld = load_data(SET_NAME)
+
+        master_data_dict[SET_NAME] = {
+            "loaded_data": ld,
+            "calculated_quantities": {}
+        }
+        for QUANTITY in QUANTITIES:
+            master_data_dict[SET_NAME]["calculated_quantities"][QUANTITY] = {}
+            print(ld["code_results"].keys())
+            for plugin, plugin_data in ld["code_results"].items():
+                collect = calculate_quantities(plugin_data, ld["compare_plugin_data"], QUANTITY)
+                master_data_dict[SET_NAME]["calculated_quantities"][QUANTITY][plugin] = collect
+
+        
+    print("Calculating a consistent colorbar scale for nu/eps.")
+    nu_colorbar_max = find_code_nu_colorbar_maximums(master_data_dict)
+
+
+    print("Plotting the periodic tables.")
+    for SET_NAME in SET_NAMES:
+        for QUANTITY in QUANTITIES:
+            plot_periodic_tables(SET_NAME, QUANTITY, nu_colorbar_max, master_data_dict)


### PR DESCRIPTION
Hi, currently this PR makes the supplementary periodic tables with a consistent colorbar, such that for each code, independently:

* the unaries and oxides periodic tables for the same metric will have the same colorbar
* epsilon and nu colorbar maximums will be related by nu=1.704*epsilon
* no data will be outside the colorbar range