### PR TITLE
Dependencies: Pin `aiida-submission-controller==0.1.2`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "selenium",
     "chromedriver-binary",
 #    "aiida-common-workflows @ git+https://github.com/aiidateam/aiida-common-workflows@v0.1.0",
-    "aiida_submission_controller @ git+https://github.com/aiidateam/aiida-submission-controller@v0.1.2"
+    "aiida_submission_controller==0.1.2",
 ]
 
 [project.urls]


### PR DESCRIPTION
Now that `aiida-submission-controller==0.1.2` is properly released, we pin this version so we don't have to update the submission scripts to the potentially changing API for this package.